### PR TITLE
Unify schema and types with consistent field prefixes

### DIFF
--- a/examples/basic-usage.ts
+++ b/examples/basic-usage.ts
@@ -27,19 +27,14 @@ async function main() {
           port: 5852,
           user: 'postgres',
           password: 'postgrespassword',
-          database: 'processkit'
+          database: 'postgres'
         }
       }
     });
-
-
-    // await schemaKit.initialize();
-
     
     // Get entity instance (now async and auto-initialized)
     try {
-      const Entity = await schemaKit.entity('entities','system');
-      console.log("userEntity");
+      const Entity = await schemaKit.entity('products','system');
       // Try to create a new user (may fail due to missing configuration)
       try {
         const Entities = await Entity.get();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@MobtakronIO/schemakit",
-  "version": "0.1.2",
+  "name": "@mobtakronio/schemakit",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@MobtakronIO/schemakit",
-      "version": "0.1.2",
+      "name": "@mobtakronio/schemakit",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@types/pg": "^8.15.4",
@@ -22,6 +22,7 @@
         "rollup-plugin-visualizer": "^6.0.3",
         "terser": "^5.43.1",
         "ts-jest": "^29.1.0",
+        "ts-node": "^10.9.2",
         "typescript": "^5.8.3",
         "vite": "^6.3.5"
       },
@@ -538,6 +539,30 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.8",
@@ -1816,6 +1841,34 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2239,6 +2292,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2311,6 +2377,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -2736,6 +2809,13 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2819,6 +2899,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-sequences": {
@@ -6080,6 +6170,50 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -6199,6 +6333,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -6446,6 +6587,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -11,19 +11,14 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc",
-    "build:esm": "tsc -p tsconfig.esm.json",
-    "build:umd": "tsc -p tsconfig.umd.json",
-    "build:all": "npm run clean && npm run build && npm run build:esm && npm run build:umd",
-    "build:vite": "vite build",
-    "analyze": "npm run build:vite && echo 'Bundle analysis available at dist/bundle-analysis.html'",
+    "build": "vite build",
+    "analyze": "npm run build && echo 'Bundle analysis available at dist/bundle-analysis.html'",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",
-    "prepublishOnly": "npm run test && npm run build:vite",
-    "prepare": "npm run build:vite"
+    "prepublishOnly": "npm run test && npm run build"
   },
   "keywords": [
     "schema",
@@ -40,7 +35,7 @@
     "runtime-schema",
     "entity-management"
   ],
-  "author": "MobtakronIO",  
+  "author": "MobtakronIO",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -66,6 +61,7 @@
     "rollup-plugin-visualizer": "^6.0.3",
     "terser": "^5.43.1",
     "ts-jest": "^29.1.0",
+    "ts-node": "^10.9.2",
     "typescript": "^5.8.3",
     "vite": "^6.3.5"
   },

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -3,108 +3,101 @@
 
 -- System entities table - stores entity definitions
 CREATE TABLE IF NOT EXISTS system_entities (
-    id TEXT PRIMARY KEY NOT NULL,
-    name TEXT NOT NULL UNIQUE,
-    table_name TEXT NOT NULL,
-    display_name TEXT NOT NULL,
-    description TEXT,
-    is_active BOOLEAN NOT NULL DEFAULT 1,
-    created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL,
-    metadata TEXT -- JSON string
+    entity_id TEXT PRIMARY KEY NOT NULL,
+    entity_name TEXT NOT NULL UNIQUE,
+    entity_table_name TEXT NOT NULL,
+    entity_display_name TEXT NOT NULL,
+    entity_description TEXT,
+    entity_is_active BOOLEAN NOT NULL DEFAULT 1,
+    entity_created_at TEXT NOT NULL,
+    entity_updated_at TEXT NOT NULL,
+    entity_metadata TEXT -- JSON string
 );
 
 -- System fields table - stores field definitions for entities
 CREATE TABLE IF NOT EXISTS system_fields (
-    id TEXT PRIMARY KEY NOT NULL,
-    entity_id TEXT NOT NULL,
-    name TEXT NOT NULL,
-    type TEXT NOT NULL,
-    is_required BOOLEAN NOT NULL DEFAULT 0,
-    is_unique BOOLEAN NOT NULL DEFAULT 0,
-    default_value TEXT,
-    validation_rules TEXT, -- JSON string
-    display_name TEXT NOT NULL,
-    description TEXT,
-    order_index INTEGER NOT NULL DEFAULT 0,
-    is_active BOOLEAN NOT NULL DEFAULT 1,
-    reference_entity TEXT,
-    metadata TEXT, -- JSON string
-    FOREIGN KEY (entity_id) REFERENCES system_entities(id) ON DELETE CASCADE
+    field_id TEXT PRIMARY KEY NOT NULL,
+    field_entity_id TEXT NOT NULL,
+    field_name TEXT NOT NULL,
+    field_type TEXT NOT NULL,
+    field_is_required BOOLEAN NOT NULL DEFAULT 0,
+    field_is_unique BOOLEAN NOT NULL DEFAULT 0,
+    field_default_value TEXT,
+    field_validation_rules TEXT, -- JSON string
+    field_display_name TEXT NOT NULL,
+    field_description TEXT,
+    field_order_index INTEGER NOT NULL DEFAULT 0,
+    field_is_active BOOLEAN NOT NULL DEFAULT 1,
+    field_reference_entity TEXT,
+    field_metadata TEXT, -- JSON string
+    FOREIGN KEY (field_entity_id) REFERENCES system_entities(entity_id) ON DELETE CASCADE
 );
 
 -- System permissions table - stores permission rules
 CREATE TABLE IF NOT EXISTS system_permissions (
-    id TEXT PRIMARY KEY NOT NULL,
-    entity_id TEXT NOT NULL,
-    role TEXT NOT NULL,
-    action TEXT NOT NULL,
-    conditions TEXT, -- JSON string
-    is_allowed BOOLEAN NOT NULL DEFAULT 1,
-    created_at TEXT NOT NULL,
-    field_permissions TEXT, -- JSON string
-    FOREIGN KEY (entity_id) REFERENCES system_entities(id) ON DELETE CASCADE
+    permission_id TEXT PRIMARY KEY NOT NULL,
+    permission_entity_id TEXT NOT NULL,
+    permission_role TEXT NOT NULL,
+    permission_action TEXT NOT NULL,
+    permission_conditions TEXT, -- JSON string
+    permission_is_allowed BOOLEAN NOT NULL DEFAULT 1,
+    permission_is_active BOOLEAN NOT NULL DEFAULT 1,
+    permission_created_at TEXT NOT NULL,
+    permission_field_permissions TEXT, -- JSON string
+    FOREIGN KEY (permission_entity_id) REFERENCES system_entities(entity_id) ON DELETE CASCADE
 );
 
 -- System views table - stores view definitions
 CREATE TABLE IF NOT EXISTS system_views (
-    id TEXT PRIMARY KEY NOT NULL,
-    entity_id TEXT NOT NULL,
-    name TEXT NOT NULL,
-    query_config TEXT NOT NULL, -- JSON string
-    fields TEXT NOT NULL, -- JSON string array
-    is_default BOOLEAN NOT NULL DEFAULT 0,
-    created_by TEXT,
-    is_public BOOLEAN NOT NULL DEFAULT 0,
-    metadata TEXT, -- JSON string
-    FOREIGN KEY (entity_id) REFERENCES system_entities(id) ON DELETE CASCADE
+    view_id TEXT PRIMARY KEY NOT NULL,
+    view_entity_id TEXT NOT NULL,
+    view_name TEXT NOT NULL,
+    view_query_config TEXT NOT NULL, -- JSON string
+    view_fields TEXT NOT NULL, -- JSON string array
+    view_is_default BOOLEAN NOT NULL DEFAULT 0,
+    view_created_by TEXT,
+    view_is_public BOOLEAN NOT NULL DEFAULT 0,
+    view_metadata TEXT, -- JSON string
+    FOREIGN KEY (view_entity_id) REFERENCES system_entities(entity_id) ON DELETE CASCADE
 );
 
 -- System workflows table - stores workflow definitions
 CREATE TABLE IF NOT EXISTS system_workflows (
-    id TEXT PRIMARY KEY NOT NULL,
-    entity_id TEXT NOT NULL,
-    name TEXT NOT NULL,
-    trigger_event TEXT NOT NULL,
-    conditions TEXT, -- JSON string
-    actions TEXT NOT NULL, -- JSON string array
-    is_active BOOLEAN NOT NULL DEFAULT 1,
-    order_index INTEGER NOT NULL DEFAULT 0,
-    metadata TEXT, -- JSON string
-    FOREIGN KEY (entity_id) REFERENCES system_entities(id) ON DELETE CASCADE
+    workflow_id TEXT PRIMARY KEY NOT NULL,
+    workflow_entity_id TEXT NOT NULL,
+    workflow_name TEXT NOT NULL,
+    workflow_trigger_event TEXT NOT NULL,
+    workflow_conditions TEXT, -- JSON string
+    workflow_actions TEXT NOT NULL, -- JSON string array
+    workflow_is_active BOOLEAN NOT NULL DEFAULT 1,
+    workflow_order_index INTEGER NOT NULL DEFAULT 0,
+    workflow_metadata TEXT, -- JSON string
+    FOREIGN KEY (workflow_entity_id) REFERENCES system_entities(entity_id) ON DELETE CASCADE
 );
 
 -- System RLS (Row Level Security) table - stores RLS rules
 CREATE TABLE IF NOT EXISTS system_rls (
-    id TEXT PRIMARY KEY NOT NULL,
-    entity_id TEXT NOT NULL,
-    role TEXT NOT NULL,
-    view_id TEXT,
+    rls_id TEXT PRIMARY KEY NOT NULL,
+    rls_entity_id TEXT NOT NULL,
+    rls_role TEXT NOT NULL,
+    rls_view_id TEXT,
     rls_config TEXT NOT NULL, -- JSON string
-    is_active BOOLEAN NOT NULL DEFAULT 1,
-    created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL,
-    FOREIGN KEY (entity_id) REFERENCES system_entities(id) ON DELETE CASCADE
+    rls_is_active BOOLEAN NOT NULL DEFAULT 1,
+    rls_created_at TEXT NOT NULL,
+    rls_updated_at TEXT NOT NULL,
+    FOREIGN KEY (rls_entity_id) REFERENCES system_entities(entity_id) ON DELETE CASCADE
 );
 
--- System installation table - tracks SchemaKit installation and version
-CREATE TABLE IF NOT EXISTS system_installation (
-    id INTEGER PRIMARY KEY,
-    version TEXT NOT NULL,
-    installed_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL,
-    metadata TEXT -- JSON string for additional info
-);
 
 -- Create indexes for better performance
-CREATE INDEX IF NOT EXISTS idx_system_fields_entity_id ON system_fields(entity_id);
-CREATE INDEX IF NOT EXISTS idx_system_fields_active ON system_fields(is_active);
-CREATE INDEX IF NOT EXISTS idx_system_permissions_entity_id ON system_permissions(entity_id);
-CREATE INDEX IF NOT EXISTS idx_system_permissions_role ON system_permissions(role);
-CREATE INDEX IF NOT EXISTS idx_system_views_entity_id ON system_views(entity_id);
-CREATE INDEX IF NOT EXISTS idx_system_workflows_entity_id ON system_workflows(entity_id);
-CREATE INDEX IF NOT EXISTS idx_system_workflows_active ON system_workflows(is_active);
-CREATE INDEX IF NOT EXISTS idx_system_rls_entity_id ON system_rls(entity_id);
-CREATE INDEX IF NOT EXISTS idx_system_rls_role ON system_rls(role);
-CREATE INDEX IF NOT EXISTS idx_system_entities_active ON system_entities(is_active);
-CREATE INDEX IF NOT EXISTS idx_system_entities_name ON system_entities(name);
+CREATE INDEX IF NOT EXISTS idx_system_fields_entity_id ON system_fields(field_entity_id);
+CREATE INDEX IF NOT EXISTS idx_system_fields_active ON system_fields(field_is_active);
+CREATE INDEX IF NOT EXISTS idx_system_permissions_entity_id ON system_permissions(permission_entity_id);
+CREATE INDEX IF NOT EXISTS idx_system_permissions_role ON system_permissions(permission_role);
+CREATE INDEX IF NOT EXISTS idx_system_views_entity_id ON system_views(view_entity_id);
+CREATE INDEX IF NOT EXISTS idx_system_workflows_entity_id ON system_workflows(workflow_entity_id);
+CREATE INDEX IF NOT EXISTS idx_system_workflows_active ON system_workflows(workflow_is_active);
+CREATE INDEX IF NOT EXISTS idx_system_rls_entity_id ON system_rls(rls_entity_id);
+CREATE INDEX IF NOT EXISTS idx_system_rls_role ON system_rls(rls_role);
+CREATE INDEX IF NOT EXISTS idx_system_entities_active ON system_entities(entity_is_active);
+CREATE INDEX IF NOT EXISTS idx_system_entities_name ON system_entities(entity_name);

--- a/src/entities/entity/entity.ts
+++ b/src/entities/entity/entity.ts
@@ -370,18 +370,18 @@ export class Entity {
     const errors: string[] = [];
 
     for (const field of this.fields) {
-      const value = data[field.name];
+      const value = data[field.field_name];
       
       if (action === 'create' && field.is_required && (value === undefined || value === null)) {
-        errors.push(`Field '${field.name}' is required`);
+        errors.push(`Field '${field.field_name}' is required`);
         continue;
       }
 
       if (action === 'update' && value === undefined) continue;
 
       if (value !== null && value !== undefined) {
-        if (!this.validateFieldType(value, field.type)) {
-          errors.push(`Field '${field.name}' must be of type ${field.type}`);
+            if (!this.validateFieldType(value, field.field_type)) {
+      errors.push(`Field '${field.field_name}' must be of type ${field.field_type}`);
         }
       }
     }
@@ -422,7 +422,7 @@ export class Entity {
     const applicableWorkflows = this.workflow.filter(w => w.trigger_event === event);
     
     for (const workflow of applicableWorkflows) {
-      console.log(`Executing workflow: ${workflow.name} for event: ${event}`);
+              console.log(`Executing workflow: ${workflow.workflow_name} for event: ${event}`);
     }
   }
 

--- a/src/entities/query/pagination-manager.ts
+++ b/src/entities/query/pagination-manager.ts
@@ -3,7 +3,8 @@
  * Handles pagination logic and calculations
  */
 import { DatabaseAdapter } from '../../database/adapter';
-import { QueryBuilder, BuiltQuery, QueryFilter } from './query-builder';
+import { QueryBuilder } from './query-builder';
+import { BuiltQuery, QueryFilter } from '../../types/database';
 import { PaginationOptions, PaginationResult } from '../../types/views';
 
 /**

--- a/src/entities/validation/type-validators.ts
+++ b/src/entities/validation/type-validators.ts
@@ -12,13 +12,13 @@ export class TypeValidators {
   static validateFieldType(field: FieldDefinition, value: any): ValidationError[] {
     const errors: ValidationError[] = [];
 
-    switch (field.type) {
+    switch (field.field_type) {
       case 'string':
         if (typeof value !== 'string') {
           errors.push({
-            field: field.name,
+            field: field.field_name,
             code: 'type',
-            message: `Field '${field.name}' must be a string`,
+            message: `Field '${field.field_name}' must be a string`,
             value
           });
         }
@@ -28,17 +28,17 @@ export class TypeValidators {
       case 'integer':
         if (typeof value !== 'number' || isNaN(value)) {
           errors.push({
-            field: field.name,
+            field: field.field_name,
             code: 'type',
-            message: `Field '${field.name}' must be a number`,
+            message: `Field '${field.field_name}' must be a number`,
             value
           });
         }
-        if (field.type === 'integer' && !Number.isInteger(value)) {
+        if (field.field_type === 'integer' && !Number.isInteger(value)) {
           errors.push({
-            field: field.name,
+            field: field.field_name,
             code: 'type',
-            message: `Field '${field.name}' must be an integer`,
+            message: `Field '${field.field_name}' must be an integer`,
             value
           });
         }
@@ -47,9 +47,9 @@ export class TypeValidators {
       case 'boolean':
         if (typeof value !== 'boolean') {
           errors.push({
-            field: field.name,
+            field: field.field_name,
             code: 'type',
-            message: `Field '${field.name}' must be a boolean`,
+            message: `Field '${field.field_name}' must be a boolean`,
             value
           });
         }
@@ -59,9 +59,9 @@ export class TypeValidators {
       case 'datetime':
         if (!this.isValidDate(value)) {
           errors.push({
-            field: field.name,
+            field: field.field_name,
             code: 'type',
-            message: `Field '${field.name}' must be a valid date`,
+            message: `Field '${field.field_name}' must be a valid date`,
             value
           });
         }
@@ -71,9 +71,9 @@ export class TypeValidators {
       case 'object':
         if (!this.isValidJson(value)) {
           errors.push({
-            field: field.name,
+            field: field.field_name,
             code: 'type',
-            message: `Field '${field.name}' must be valid JSON`,
+            message: `Field '${field.field_name}' must be valid JSON`,
             value
           });
         }
@@ -82,9 +82,9 @@ export class TypeValidators {
       case 'array':
         if (!Array.isArray(value)) {
           errors.push({
-            field: field.name,
+            field: field.field_name,
             code: 'type',
-            message: `Field '${field.name}' must be an array`,
+            message: `Field '${field.field_name}' must be an array`,
             value
           });
         }
@@ -93,9 +93,9 @@ export class TypeValidators {
       case 'reference':
         if (typeof value !== 'string' && typeof value !== 'number') {
           errors.push({
-            field: field.name,
+            field: field.field_name,
             code: 'type',
-            message: `Field '${field.name}' must be a valid reference ID`,
+            message: `Field '${field.field_name}' must be a valid reference ID`,
             value
           });
         }

--- a/src/entities/validation/validation-manager.ts
+++ b/src/entities/validation/validation-manager.ts
@@ -22,7 +22,7 @@ export class ValidationManager {
     
     // Validate each field
     for (const field of entityConfig.fields) {
-      const fieldErrors = this.validateField(field, data[field.name], operation, data);
+      const fieldErrors = this.validateField(field, data[field.field_name], operation, data);
       errors.push(...fieldErrors);
     }
     
@@ -80,13 +80,13 @@ export class ValidationManager {
   private validateFieldType(field: FieldDefinition, value: any): ValidationError[] {
     const errors: ValidationError[] = [];
 
-    switch (field.type) {
+    switch (field.field_type) {
       case 'string':
         if (typeof value !== 'string') {
           errors.push({
-            field: field.name,
+            field: field.field_name,
             code: 'type',
-            message: `Field '${field.name}' must be a string`,
+            message: `Field '${field.field_name}' must be a string`,
             value
           });
         }
@@ -96,9 +96,9 @@ export class ValidationManager {
       case 'integer':
         if (typeof value !== 'number' || isNaN(value)) {
           errors.push({
-            field: field.name,
+            field: field.field_name,
             code: 'type',
-            message: `Field '${field.name}' must be a number`,
+            message: `Field '${field.field_name}' must be a number`,
             value
           });
         }
@@ -107,9 +107,9 @@ export class ValidationManager {
       case 'boolean':
         if (typeof value !== 'boolean') {
           errors.push({
-            field: field.name,
+            field: field.field_name,
             code: 'type',
-            message: `Field '${field.name}' must be a boolean`,
+            message: `Field '${field.field_name}' must be a boolean`,
             value
           });
         }
@@ -119,9 +119,9 @@ export class ValidationManager {
       case 'datetime':
         if (!(value instanceof Date) && isNaN(Date.parse(value))) {
           errors.push({
-            field: field.name,
+            field: field.field_name,
             code: 'type',
-            message: `Field '${field.name}' must be a valid date`,
+            message: `Field '${field.field_name}' must be a valid date`,
             value
           });
         }
@@ -131,9 +131,9 @@ export class ValidationManager {
       case 'object':
         if (typeof value !== 'object' || value === null) {
           errors.push({
-            field: field.name,
+            field: field.field_name,
             code: 'type',
-            message: `Field '${field.name}' must be an object`,
+            message: `Field '${field.field_name}' must be an object`,
             value
           });
         }
@@ -142,9 +142,9 @@ export class ValidationManager {
       case 'array':
         if (!Array.isArray(value)) {
           errors.push({
-            field: field.name,
+            field: field.field_name,
             code: 'type',
-            message: `Field '${field.name}' must be an array`,
+            message: `Field '${field.field_name}' must be an array`,
             value
           });
         }
@@ -161,16 +161,16 @@ export class ValidationManager {
     const errors: ValidationError[] = [];
 
     try {
-      const rules = typeof field.validation_rules === 'string' 
-        ? JSON.parse(field.validation_rules) 
-        : field.validation_rules;
+      const rules = typeof field.field_validation_rules === 'string' 
+        ? JSON.parse(field.field_validation_rules) 
+        : field.field_validation_rules;
 
       // Min length
       if (rules.minLength && typeof value === 'string' && value.length < rules.minLength) {
         errors.push({
           field: field.name,
           code: 'minLength',
-          message: `Field '${field.name}' must be at least ${rules.minLength} characters`,
+                      message: `Field '${field.field_name}' must be at least ${rules.minLength} characters`,
           value
         });
       }
@@ -180,7 +180,7 @@ export class ValidationManager {
         errors.push({
           field: field.name,
           code: 'maxLength',
-          message: `Field '${field.name}' must be at most ${rules.maxLength} characters`,
+                      message: `Field '${field.field_name}' must be at most ${rules.maxLength} characters`,
           value
         });
       }
@@ -190,7 +190,7 @@ export class ValidationManager {
         errors.push({
           field: field.name,
           code: 'min',
-          message: `Field '${field.name}' must be at least ${rules.min}`,
+                      message: `Field '${field.field_name}' must be at least ${rules.min}`,
           value
         });
       }
@@ -200,7 +200,7 @@ export class ValidationManager {
         errors.push({
           field: field.name,
           code: 'max',
-          message: `Field '${field.name}' must be at most ${rules.max}`,
+                      message: `Field '${field.field_name}' must be at most ${rules.max}`,
           value
         });
       }
@@ -210,9 +210,9 @@ export class ValidationManager {
         const regex = new RegExp(rules.pattern);
         if (!regex.test(value)) {
           errors.push({
-            field: field.name,
+            field: field.field_name,
             code: 'pattern',
-            message: `Field '${field.name}' does not match required pattern`,
+            message: `Field '${field.field_name}' does not match required pattern`,
             value
           });
         }
@@ -223,9 +223,9 @@ export class ValidationManager {
         const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
         if (!emailRegex.test(value)) {
           errors.push({
-            field: field.name,
+            field: field.field_name,
             code: 'email',
-            message: `Field '${field.name}' must be a valid email address`,
+            message: `Field '${field.field_name}' must be a valid email address`,
             value
           });
         }
@@ -235,7 +235,7 @@ export class ValidationManager {
       errors.push({
         field: field.name,
         code: 'validation_error',
-        message: `Invalid validation rules for field '${field.name}'`,
+                    message: `Invalid validation rules for field '${field.field_name}'`,
         value
       });
     }

--- a/src/entities/views/view-manager.ts
+++ b/src/entities/views/view-manager.ts
@@ -40,7 +40,7 @@ export class ViewManager {
     options: ViewOptions = {}
   ): Promise<ViewResult> {
     // Find the view definition
-    const viewDef = this.views.find(v => v.name === viewName);
+    const viewDef = this.views.find(v => v.view_name === viewName);
     if (!viewDef) {
       throw new Error(`View '${viewName}' not found for entity '${this.entityName}'`);
     }

--- a/src/entities/workflow/workflow-manager.ts
+++ b/src/entities/workflow/workflow-manager.ts
@@ -52,7 +52,7 @@ export class WorkflowManager {
       try {
         await this.executeWorkflow(workflow, event, oldData, newData, context);
       } catch (error) {
-        console.error(`Error executing workflow ${workflow.name}: ${error}`);
+        console.error(`Error executing workflow ${workflow.workflow_name}: ${error}`);
         // In a production system, you might want to handle workflow errors differently
         // For now, we'll log the error and continue
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,8 +28,36 @@ export { SchemaLoader } from './database/schema-loader';
 
 // Database module (new structure) - Main gateway for all database operations
 export * from './database';
-// Types (simplified)
-export * from './types';
+// Types (simplified) - export specific types to avoid conflicts
+export type {
+  EntityDefinition,
+  FieldDefinition,
+  EntityConfiguration,
+  Context,
+  SchemaKitOptions,
+  FieldType,
+  OperationType,
+  QueryFilter,
+  QueryOptions,
+  QueryResult,
+  BuiltQuery,
+  PermissionDefinition,
+  RLSCondition,
+  RLSRule,
+  RLSDefinition,
+  RoleRestrictions,
+  ViewDefinition,
+  ViewOptions,
+  ViewResult,
+  PaginationOptions,
+  SortDefinition,
+  JoinDefinition,
+  WorkflowDefinition,
+  WorkflowAction,
+  ValidationResult,
+  ValidationError,
+  ValidationWarning
+} from './types';
 
 // Errors
 export { SchemaKitError } from './errors';
@@ -38,6 +66,5 @@ export { SchemaKitError } from './errors';
 export * from './utils/date-helpers';
 export * from './utils/id-generation';
 export * from './utils/json-helpers';
-export * from './utils/query-helpers';
 export * from './utils/validation-helpers';
 export { Logger } from './utils/logger';

--- a/src/types/core/entities.ts
+++ b/src/types/core/entities.ts
@@ -83,35 +83,35 @@ export interface EntityDefinition {
  */
 export interface FieldDefinition {
   /** Unique identifier for this field */
-  id: string;
+  field_id: string;
   /** ID of the entity this field belongs to */
-  entity_id: string;
+  field_entity_id: string;
   /** Field name used in code (e.g., 'email', 'created_at') */
-  name: string;
+  field_name: string;
   /** Data type of this field */
-  type: FieldType;
+  field_type: FieldType;
   /** Whether this field must have a value */
-  is_required: boolean;
+  field_is_required: boolean;
   /** Whether values in this field must be unique */
-  is_unique: boolean;
+  field_is_unique: boolean;
   /** Whether this field is part of the primary key */
-  is_primary_key?: boolean;
+  field_is_primary_key?: boolean;
   /** Default value for new records (as string) */
-  default_value?: string;
+  field_default_value?: string;
   /** Validation rules as JSON object */
-  validation_rules?: Record<string, any>;
+  field_validation_rules?: Record<string, any>;
   /** Human-readable display name */
-  display_name: string;
+  field_display_name: string;
   /** Description of what this field represents */
-  description?: string;
+  field_description?: string;
   /** Display order (0-based index) */
-  order_index: number;
+  field_order_index: number;
   /** Whether this field is currently active */
-  is_active: boolean;
+  field_is_active: boolean;
   /** Entity name this field references (for foreign keys) */
-  reference_entity?: string;
+  field_reference_entity?: string;
   /** Additional metadata as JSON object */
-  metadata?: Record<string, any>;
+  field_metadata?: Record<string, any>;
 }
 
 /**

--- a/src/types/permissions/permissions.ts
+++ b/src/types/permissions/permissions.ts
@@ -63,21 +63,21 @@ import { OperationType } from '../core/common';
  */
 export interface PermissionDefinition {
   /** Unique identifier for this permission rule */
-  id: string;
+  permission_id: string;
   /** ID of the entity this permission applies to */
-  entity_id: string;
+  permission_entity_id: string;
   /** Role name this permission is granted to */
-  role: string;
+  permission_role: string;
   /** Operation type this permission controls */
-  action: OperationType;
+  permission_action: OperationType;
   /** Optional conditions that must be met (JSON object) */
-  conditions?: Record<string, any>;
+  permission_conditions?: Record<string, any>;
   /** Whether this permission grants (true) or denies (false) access */
-  is_allowed: boolean;
+  permission_is_allowed: boolean;
   /** Whether this permission rule is currently active */
-  is_active?: boolean;
+  permission_is_active?: boolean;
   /** ISO timestamp when permission was created */
-  created_at: string;
+  permission_created_at: string;
   /** Field-level permissions (field_name: allowed, field_name_read: read_only) */
-  field_permissions?: Record<string, boolean>;
+  permission_field_permissions?: Record<string, boolean>;
 }

--- a/src/types/permissions/rls.ts
+++ b/src/types/permissions/rls.ts
@@ -145,13 +145,13 @@ export interface RoleRestrictions {
  */
 export interface RLSDefinition {
   /** Unique identifier for this RLS rule */
-  id: string;
+  rls_id: string;
   /** Entity this rule applies to */
-  entity_id: string;
+  rls_entity_id: string;
   /** Role this rule applies to */
-  role: string;
+  rls_role: string;
   /** Optional view this rule is specific to */
-  view_id?: string;
+  rls_view_id?: string;
   /** RLS configuration */
   rls_config: {
     /** How to combine multiple conditions */
@@ -160,11 +160,11 @@ export interface RLSDefinition {
     conditions: RLSCondition[];
   };
   /** Whether this rule is currently active */
-  is_active: boolean;
+  rls_is_active: boolean;
   /** ISO timestamp when rule was created */
-  created_at: string;
+  rls_created_at: string;
   /** ISO timestamp when rule was last updated */
-  updated_at: string;
+  rls_updated_at: string;
 }
 
 /**

--- a/src/types/views/pagination.ts
+++ b/src/types/views/pagination.ts
@@ -4,18 +4,26 @@
 
 export interface PaginationOptions {
   page?: number;
+  pageSize?: number;
   limit?: number;
   offset?: number;
 }
 
 export interface PaginationResult<T = any> {
   data: T[];
-  pagination: {
+  pagination?: {
     current_page: number;
     per_page: number;
     total: number;
     total_pages: number;
     has_previous: boolean;
     has_next: boolean;
+  };
+  meta?: {
+    total: number;
+    page: number;
+    per_page: number;
+    has_more: boolean;
+    total_pages: number;
   };
 }

--- a/src/types/views/views.ts
+++ b/src/types/views/views.ts
@@ -118,13 +118,13 @@ export interface PaginationDefinition {
  */
 export interface ViewDefinition {
   /** Unique identifier for this view */
-  id: string;
+  view_id: string;
   /** Entity this view applies to */
-  entity_id: string;
+  view_entity_id: string;
   /** View name for reference */
-  name: string;
+  view_name: string;
   /** Query configuration */
-  query_config: {
+  view_query_config: {
     /** Fixed filters applied to all executions */
     filters?: Record<string, any>;
     /** Entity joins to include related data */
@@ -135,15 +135,15 @@ export interface ViewDefinition {
     pagination?: PaginationDefinition;
   };
   /** Fields to include in results (empty = all fields) */
-  fields: string[];
+  view_fields: string[];
   /** Whether this is the default view for the entity */
-  is_default: boolean;
+  view_is_default: boolean;
   /** User who created this view */
-  created_by?: string;
+  view_created_by?: string;
   /** Whether other users can use this view */
-  is_public: boolean;
+  view_is_public: boolean;
   /** Additional metadata */
-  metadata?: Record<string, any>;
+  view_metadata?: Record<string, any>;
 }
 
 /**

--- a/src/types/workflows/workflows.ts
+++ b/src/types/workflows/workflows.ts
@@ -151,21 +151,21 @@ export interface WorkflowAction {
  */
 export interface WorkflowDefinition {
   /** Unique identifier for this workflow */
-  id: string;
+  workflow_id: string;
   /** Entity this workflow applies to */
-  entity_id: string;
+  workflow_entity_id: string;
   /** Workflow name for reference */
-  name: string;
+  workflow_name: string;
   /** Event that triggers this workflow */
-  trigger_event: WorkflowTrigger;
+  workflow_trigger_event: WorkflowTrigger;
   /** Optional conditions that must be met to execute */
-  conditions?: Record<string, any>;
+  workflow_conditions?: Record<string, any>;
   /** Array of actions to execute in order */
-  actions: WorkflowAction[];
+  workflow_actions: WorkflowAction[];
   /** Whether this workflow is currently active */
-  is_active: boolean;
+  workflow_is_active: boolean;
   /** Execution order when multiple workflows match */
-  order_index: number;
+  workflow_order_index: number;
   /** Additional metadata */
-  metadata?: Record<string, any>;
+  workflow_metadata?: Record<string, any>;
 }


### PR DESCRIPTION
- Updated schema.sql to use consistent prefixes for all system tables:
  - system_entities: entity_id, entity_name, entity_table_name, etc.
  - system_fields: field_id, field_entity_id, field_name, field_type, etc.
  - system_permissions: permission_id, permission_entity_id, permission_role, etc.
  - system_views: view_id, view_entity_id, view_name, etc.
  - system_workflows: workflow_id, workflow_entity_id, workflow_name, etc.
  - system_rls: rls_id, rls_entity_id, rls_role, etc.

- Updated TypeScript types to match prefixed field names:
  - FieldDefinition, PermissionDefinition, ViewDefinition, WorkflowDefinition, RLSDefinition
  - EntityDefinition already had entity_ prefix

- Fixed all code implementations to use new field names:
  - Entity validation logic and type validators
  - View and workflow managers
  - InMemory database adapter with table-specific ID field handling
  - All foreign key references and indexes updated
- Achieved perfect alignment between database schema and TypeScript types